### PR TITLE
Broken website link fix in ReadME

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Bring your ideas to life.
 
-**Website:** [ourzora.com](ourzora.com)
+**Website:** [ourzora.com](http://ourzora.com)
 **Instagram:** [@our.zora](instagram.com/our.zora)
 **Twitter:** [@ourZORA](twitter.com/ourZORA)
 


### PR DESCRIPTION
**Problem** 
Link under Website: [ourzora.com](ourzora.com) gives a 404. It directs to the link: https://github.com/ourzora/zora-contracts/blob/master/ourzora.com.

**Solution**
Fixed with full link: http://ourzora.com